### PR TITLE
Marcos3 pr to main

### DIFF
--- a/app/src/components/controlPanel/RoutePlanner.tsx
+++ b/app/src/components/controlPanel/RoutePlanner.tsx
@@ -68,6 +68,7 @@ const RoutePlanner = ({ setActiveView }: { setActiveView: (view: ViewMode) => vo
   const [showDepartureFilter, setShowDepartureFilter] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [defaultDate, setDefaultDate] = useState<Date | null>(null);
+  const [isArrival, setIsArrival] = useState(false);
   const [originAutocompleteData, setOriginAutocompleteData] = useState<AutocompleteItem[]>([]);
   const [destinationAutocompleteData, setDestinationAutocompleteData] = useState<AutocompleteItem[]>([]);
   
@@ -97,7 +98,7 @@ const RoutePlanner = ({ setActiveView }: { setActiveView: (view: ViewMode) => vo
   }, []);
   
   const isDepartureModified = selectedDate && defaultDate 
-    ? selectedDate.getTime() !== defaultDate.getTime()
+    ? selectedDate.getTime() !== defaultDate.getTime() || isArrival
     : false;
     
   const formattedTime = selectedDate
@@ -315,7 +316,8 @@ const RoutePlanner = ({ setActiveView }: { setActiveView: (view: ViewMode) => vo
         From: selectedOrigin.coordinates,
         To: selectedDestination.coordinates,
         Travelmode: transportModes,
-        numItineraries: 5,  
+        numItineraries: 5,
+        arriveBy: isArrival
       };
 
       if (selectedDate) {
@@ -337,7 +339,8 @@ const RoutePlanner = ({ setActiveView }: { setActiveView: (view: ViewMode) => vo
         To: params.To,
         Travelmode: params.Travelmode,
         date: params.date,
-        time: params.time
+        time: params.time,
+        arriveBy: params.arriveBy
       });
 
       await fetchOtpData(params);
@@ -563,6 +566,8 @@ const RoutePlanner = ({ setActiveView }: { setActiveView: (view: ViewMode) => vo
         <DepartureFilter 
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
+          isArrival={isArrival}
+          setIsArrival={setIsArrival}
         />
       )}
       {showFilters && (

--- a/app/src/components/controlPanel/RouteView.tsx
+++ b/app/src/components/controlPanel/RouteView.tsx
@@ -94,7 +94,8 @@ const RouteView = ({ setActiveView }: { setActiveView: (view: ViewMode) => void 
       Travelmode: lastTransportModes as TransportMode[],
       date: lastDate,
       time: adjustedTime,
-      numItineraries: 5,  
+      numItineraries: 5,
+      arriveBy: false  // Always use departure time for earlier/later buttons
     };
     fetchOtpData(params);
   };
@@ -124,7 +125,8 @@ const RouteView = ({ setActiveView }: { setActiveView: (view: ViewMode) => void 
       Travelmode: lastTransportModes as TransportMode[],
       date: lastDate,
       time: adjustedTime,
-      numItineraries: 5,  
+      numItineraries: 5,
+      arriveBy: false  // Always use departure time for earlier/later buttons
     };
     fetchOtpData(params);
   };

--- a/app/src/components/controlPanel/filters/DepartureFilter.tsx
+++ b/app/src/components/controlPanel/filters/DepartureFilter.tsx
@@ -5,12 +5,19 @@ import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown } from "lucide-react"
 interface DepartureFilterProps {
   selectedDate: Date | null;
   setSelectedDate: (date: Date) => void;
+  isArrival?: boolean;
+  setIsArrival?: (isArrival: boolean) => void;
 }
 
-const DepartureFilter = ({ selectedDate, setSelectedDate }: DepartureFilterProps) => {
+const DepartureFilter = ({ 
+  selectedDate, 
+  setSelectedDate, 
+  isArrival = false, 
+  setIsArrival 
+}: DepartureFilterProps) => {
   const { translations } = useSettingsContext();
   const [isMounted, setIsMounted] = useState(false);
-  const [activeTab, setActiveTab] = useState<"departure" | "arrival">("departure");
+  const [activeTab, setActiveTab] = useState<"departure" | "arrival">(isArrival ? "arrival" : "departure");
   const [selectedHour, setSelectedHour] = useState<number>(13);
   const [selectedMinute, setSelectedMinute] = useState<number>(30);
 
@@ -66,6 +73,13 @@ const DepartureFilter = ({ selectedDate, setSelectedDate }: DepartureFilterProps
   const decrementMinute = () => {
     const newMinute = (selectedMinute - 1 + 60) % 60;
     handleTimeChange(selectedHour, newMinute);
+  };
+
+  const handleTabChange = (tab: "departure" | "arrival") => {
+    setActiveTab(tab);
+    if (setIsArrival) {
+      setIsArrival(tab === "arrival");
+    }
   };
 
   const generateCalendar = () => {
@@ -150,7 +164,7 @@ const DepartureFilter = ({ selectedDate, setSelectedDate }: DepartureFilterProps
               ? "bg-primary-blue text-white"
               : "bg-gray-100 text-gray-600 hover:bg-gray-200"
           }`}
-          onClick={() => setActiveTab("departure")}
+          onClick={() => handleTabChange("departure")}
         >
           {translations?.ControlPanel?.planner?.filters?.datePicker?.departure || "Abfahrt"}
         </button>
@@ -160,7 +174,7 @@ const DepartureFilter = ({ selectedDate, setSelectedDate }: DepartureFilterProps
               ? "bg-primary-blue text-white"
               : "bg-gray-100 text-gray-600 hover:bg-gray-200"
           }`}
-          onClick={() => setActiveTab("arrival")}
+          onClick={() => handleTabChange("arrival")}
         >
           {translations?.ControlPanel?.planner?.filters?.datePicker?.arrival || "Ankunft"}
         </button>


### PR DESCRIPTION
This pull request introduces a new feature to the `RoutePlanner` component, allowing users to specify whether they want to plan their route based on arrival time instead of departure time. The most important changes include adding state management for the arrival time feature, updating the route planning logic, and modifying the `DepartureFilter` component to support this new functionality.

Enhancements to route planning:

* [`app/src/components/controlPanel/RoutePlanner.tsx`](diffhunk://#diff-3000c7f0d20b378f240ddc6f6ff17920d57f4e421130c5be9329ca6f435b3390R71): Added `isArrival` state and updated route planning logic to include the `arriveBy` parameter. [[1]](diffhunk://#diff-3000c7f0d20b378f240ddc6f6ff17920d57f4e421130c5be9329ca6f435b3390R71) [[2]](diffhunk://#diff-3000c7f0d20b378f240ddc6f6ff17920d57f4e421130c5be9329ca6f435b3390L100-R101) [[3]](diffhunk://#diff-3000c7f0d20b378f240ddc6f6ff17920d57f4e421130c5be9329ca6f435b3390R320) [[4]](diffhunk://#diff-3000c7f0d20b378f240ddc6f6ff17920d57f4e421130c5be9329ca6f435b3390L340-R343) [[5]](diffhunk://#diff-3000c7f0d20b378f240ddc6f6ff17920d57f4e421130c5be9329ca6f435b3390R569-R570)

* [`app/src/components/controlPanel/RouteView.tsx`](diffhunk://#diff-84411ac704c2a3e03e9cff6a97bb2f0dce4a9f090c72b9163325fa486ef0cc51R98): Ensured that the `arriveBy` parameter is set to `false` when using the earlier/later buttons. [[1]](diffhunk://#diff-84411ac704c2a3e03e9cff6a97bb2f0dce4a9f090c72b9163325fa486ef0cc51R98) [[2]](diffhunk://#diff-84411ac704c2a3e03e9cff6a97bb2f0dce4a9f090c72b9163325fa486ef0cc51R129)

Updates to `DepartureFilter` component:

* [`app/src/components/controlPanel/filters/DepartureFilter.tsx`](diffhunk://#diff-fe0ba4a0d51115aa42d496a99d4899ceb91489e2b7ef481f4d6312d0b66b625aR8-R20): Added `isArrival` and `setIsArrival` props, updated the tab change logic to handle arrival time, and modified the tab click handlers. [[1]](diffhunk://#diff-fe0ba4a0d51115aa42d496a99d4899ceb91489e2b7ef481f4d6312d0b66b625aR8-R20) [[2]](diffhunk://#diff-fe0ba4a0d51115aa42d496a99d4899ceb91489e2b7ef481f4d6312d0b66b625aR78-R84) [[3]](diffhunk://#diff-fe0ba4a0d51115aa42d496a99d4899ceb91489e2b7ef481f4d6312d0b66b625aL153-R167) [[4]](diffhunk://#diff-fe0ba4a0d51115aa42d496a99d4899ceb91489e2b7ef481f4d6312d0b66b625aL163-R177)